### PR TITLE
Add guarded GoReleaser automerge workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@
 # For more information see: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 * @openai/sdks-team
+.github/CODEOWNERS @openai/sdks-team
+.github/workflows/* @openai/sdks-team

--- a/.github/workflows/auto-merge-goreleaser.yml
+++ b/.github/workflows/auto-merge-goreleaser.yml
@@ -1,0 +1,96 @@
+name: Auto-merge GoReleaser cask PRs
+
+on:
+  workflow_run:
+    workflows:
+      - Validate cask
+    types:
+      - completed
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: goreleaser-automerge-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  automerge:
+    name: Auto-merge trusted GoReleaser PR
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Verify PR is an eligible GoReleaser cask update
+        id: verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          REPO: ${{ github.repository }}
+          VALIDATED_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          VALIDATED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PR_NUMBER}" ]; then
+            echo "No pull request was attached to this workflow_run event."
+            exit 1
+          fi
+
+          data="$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
+            --json author,baseRefName,body,files,headRefName,headRefOid,headRepositoryOwner,isCrossRepository,isDraft,state,statusCheckRollup)"
+
+          echo "${data}" | jq -e \
+            --arg sha "${VALIDATED_SHA}" \
+            --arg head_branch "${VALIDATED_HEAD_BRANCH}" \
+            '
+              .state == "OPEN" and
+              .isDraft == false and
+              .author.login == "app/openai-homebrew-releaser" and
+              .baseRefName == "main" and
+              .headRefName == $head_branch and
+              (.headRefName | test("^openai-[0-9]+\\.[0-9]+\\.[0-9]+$")) and
+              .headRefOid == $sha and
+              .headRepositoryOwner.login == "openai" and
+              .isCrossRepository == false and
+              ((.body // "") | contains("Automated with [GoReleaser]")) and
+              (.files | length == 1) and
+              (.files[0].path == "Casks/openai.rb") and
+              any(.statusCheckRollup[]?;
+                .__typename == "CheckRun" and
+                .workflowName == "Validate cask" and
+                .name == "validate-cask" and
+                .status == "COMPLETED" and
+                .conclusion == "SUCCESS"
+              )
+            '
+
+          changed_files="$(gh pr diff "${PR_NUMBER}" --repo "${REPO}" --name-only)"
+          if [ "${changed_files}" != "Casks/openai.rb" ]; then
+            echo "Unexpected changed files:"
+            printf '%s\n' "${changed_files}"
+            exit 1
+          fi
+
+          echo "pr-number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+
+      - name: Squash merge PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.verify.outputs.pr-number }}
+          REPO: ${{ github.repository }}
+          VALIDATED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          gh pr merge "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --squash \
+            --admin \
+            --delete-branch \
+            --match-head-commit "${VALIDATED_SHA}"

--- a/.github/workflows/auto-merge-goreleaser.yml
+++ b/.github/workflows/auto-merge-goreleaser.yml
@@ -18,12 +18,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  automerge:
-    name: Auto-merge trusted GoReleaser PR
+  verify:
+    name: Verify trusted GoReleaser PR
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    outputs:
+      pr-number: ${{ steps.verify.outputs.pr-number }}
 
     steps:
       - name: Verify PR is an eligible GoReleaser cask update
@@ -79,10 +81,24 @@ jobs:
 
           echo "pr-number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
 
+  automerge:
+    name: Auto-merge trusted GoReleaser PR
+    needs: verify
+    runs-on: ubuntu-latest
+    environment: goreleaser-automerge
+
+    steps:
+      - name: Create GoReleaser app token
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Squash merge PR
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.verify.outputs.pr-number }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ needs.verify.outputs.pr-number }}
           REPO: ${{ github.repository }}
           VALIDATED_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |

--- a/scripts/set-goreleaser-automerge-secrets.sh
+++ b/scripts/set-goreleaser-automerge-secrets.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="openai/homebrew-tools"
+environment="goreleaser-automerge"
+app_id="${RELEASE_APP_ID:-}"
+private_key_file="${RELEASE_APP_PRIVATE_KEY_FILE:-}"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/set-goreleaser-automerge-secrets.sh \
+    --app-id <github-app-id> \
+    --private-key-file <path-to-private-key.pem>
+
+Options:
+  --repo <owner/repo>              Defaults to openai/homebrew-tools.
+  --environment <name>            Defaults to goreleaser-automerge.
+  --app-id <id>                   GitHub App ID. Can also use RELEASE_APP_ID.
+  --private-key-file <path>       PEM private key path. Can also use RELEASE_APP_PRIVATE_KEY_FILE.
+  -h, --help                      Show this help.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      repo="${2:?missing value for --repo}"
+      shift 2
+      ;;
+    --environment)
+      environment="${2:?missing value for --environment}"
+      shift 2
+      ;;
+    --app-id)
+      app_id="${2:?missing value for --app-id}"
+      shift 2
+      ;;
+    --private-key-file)
+      private_key_file="${2:?missing value for --private-key-file}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "${app_id}" ]]; then
+  echo "Missing --app-id or RELEASE_APP_ID." >&2
+  exit 2
+fi
+
+if [[ -z "${private_key_file}" ]]; then
+  echo "Missing --private-key-file or RELEASE_APP_PRIVATE_KEY_FILE." >&2
+  exit 2
+fi
+
+if [[ ! -f "${private_key_file}" ]]; then
+  echo "Private key file does not exist: ${private_key_file}" >&2
+  exit 2
+fi
+
+if ! gh auth status --hostname github.com >/dev/null; then
+  echo "GitHub CLI is not authenticated for github.com." >&2
+  exit 2
+fi
+
+gh api "repos/${repo}/environments/${environment}" >/dev/null
+
+gh secret set RELEASE_APP_ID \
+  --repo "${repo}" \
+  --env "${environment}" \
+  --body "${app_id}"
+
+gh secret set RELEASE_APP_PRIVATE_KEY \
+  --repo "${repo}" \
+  --env "${environment}" \
+  < "${private_key_file}"
+
+echo "Updated RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY in ${repo}/${environment}."


### PR DESCRIPTION
## Summary

Adds a privileged workflow_run automerge path for trusted GoReleaser cask update PRs after the existing Validate cask workflow passes.

The merge workflow refuses to run unless the PR is still open, non-draft, same-repo, authored by app/openai-homebrew-releaser, targets main, uses the expected openai-x.y.z branch shape, has the same head SHA that passed validation, has a successful validate-cask check, and changes only Casks/openai.rb. The merge command also uses --match-head-commit to close the final race before squash merging.

Also makes CODEOWNERS coverage for .github/CODEOWNERS and .github/workflows/* explicit.
