### PR TITLE
Harden cask validation checkout

### DIFF
--- a/.github/workflows/validate-cask.yml
+++ b/.github/workflows/validate-cask.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Check Ruby syntax
         run: ruby -c Casks/openai.rb


### PR DESCRIPTION
## Summary

Adds `persist-credentials: false` to the cask validation workflow checkout. The validation job only reads and checks the tap, so later Homebrew/Ruby steps do not need reusable checkout Git credentials.